### PR TITLE
refactor: subtitleText to center

### DIFF
--- a/lib/pages/teaser.dart
+++ b/lib/pages/teaser.dart
@@ -74,7 +74,13 @@ class _TeaserState extends State<_Teaser> with SingleTickerProviderStateMixin {
           ),
           Text('FlutterKaigi', style: titleTextStyle),
           const Gap(32),
-          Text('@ONLINE / November 29-30, 2021', style: subtitleTextStyle),
+          Center(
+            child: Text(
+              '@ONLINE / November 29-30, 2021',
+              style: subtitleTextStyle,
+              textAlign: TextAlign.center,
+            ),
+          ),
           const Gap(32),
           CountdownTimer(
             controller: controller,


### PR DESCRIPTION
遅ればせながら気付いたので PR を切らせていただきました
変更内容: 左寄せ→中央寄せ

|subtitleText to center|
|:---:|
|<img width="288" alt="スクリーンショット 2021-11-19 21 07 37" src="https://user-images.githubusercontent.com/9650581/142621582-5f49603b-ad91-4387-a831-604eae83673b.png">|
