### PR TITLE
fix: corrected speakers' names displayed in Sessions page

### DIFF
--- a/lib/data/speaker.dart
+++ b/lib/data/speaker.dart
@@ -82,7 +82,7 @@ final kSpeakerList = {
   },
   9: {
     'title': 'Textの構造を理解する',
-    'name': 'kafumi',
+    'name': 'batch',
     'datetime': '11/30 19:10-19:40',
     'twitter': 'https://twitter.com/b4tchkn',
     'fortee':
@@ -91,7 +91,7 @@ final kSpeakerList = {
   },
   10: {
     'title': 'アクセシビリティが高いFlutterアプリケーションを開発する',
-    'name': 'kafumi',
+    'name': '1059999',
     'datetime': '11/30 19:45-20:15',
     'twitter': 'https://twitter.com/akihisasen',
     'fortee':


### PR DESCRIPTION
Corrected wrong speakers' names which are displayed in Sessions page.

|Before|After|
|---|---|
|<img width="652" alt="Screen_Shot_2021-11-28_at_4_20_29_PM" src="https://user-images.githubusercontent.com/12084705/143733685-6e393973-3afc-4bb0-82a8-74f33cbfc5c2.png">|<img width="652" alt="Screen_Shot_2021-11-28_at_4_21_24_PM" src="https://user-images.githubusercontent.com/12084705/143733709-65fe2d59-9445-4b21-b1a5-693ea6830955.png">|